### PR TITLE
Reword status output

### DIFF
--- a/lib/sahara/session.rb
+++ b/lib/sahara/session.rb
@@ -183,14 +183,14 @@ module Sahara
               if is_vm_created?(name)
                 yield name
               else
-                puts "[#{name}] - machine needs to be upped first"
+                puts "[#{name}] - machine not created"
               end
             end
           else
             if is_vm_created?(name)
               yield name
             else
-              puts "[#{name}] - machine needs to be upped first"
+              puts "[#{name}] - machine not created"
             end
           end
         end
@@ -198,7 +198,7 @@ module Sahara
         if is_vm_created?(selection)
           yield selection
         else
-          puts "[#{selection}] - machine needs to be upped first"
+          puts "[#{selection}] - machine not created"
         end
       end
     end


### PR DESCRIPTION
I find the current output of `vagrant sandbox status` quite confusing. The wording `machine needs to be upped first` suggests that the machine isn't currently running, as opposed to the fact that it's not been created yet.

The tiny PR aligns it to the `vagrant status` output of `machine not created`. It also fixes some indentation around the same piece of code.
