### PR TITLE
support kvm provider

### DIFF
--- a/lib/sahara/session/factory.rb
+++ b/lib/sahara/session/factory.rb
@@ -10,10 +10,13 @@ module Sahara
           Virtualbox.new(machine)
         when :libvirt
           require_relative "libvirt"
-          Libvirt.new(machine)
+          ProviderLibvirt.new(machine)
         when :parallels
           require_relative "parallels"
           Parallels.new(machine)
+        when :kvm
+	        require_relative "kvm"
+	        Kvm.new(machine)
         else
           raise Sahara::Errors::ProviderNotSupported
         end


### PR DESCRIPTION
support KVM provider

I need to rename Libvirt as ProviderLibvirt to name congestion,
because ruby-libvirt has Libvirt namespace.

Signed-off-by: Hiroshi Miura miurahr@linux.com
