### PR TITLE
If using the kvm driver, still connect via qemu

### DIFF
--- a/lib/sahara/session/libvirt.rb
+++ b/lib/sahara/session/libvirt.rb
@@ -18,6 +18,10 @@ module Sahara
 
         # Setup connection uri.
         uri = config.driver
+        if uri == "kvm"
+          uri = "qemu"
+        end
+
         if config.connect_via_ssh
           uri << '+ssh://'
           if config.username


### PR DESCRIPTION
When using libvirt.driver = 'kvm', the connection will fail unless you use qemu:// as the connection uri.  This pull request will allow users to use the kvm driver (much better performance) but still have Sahara work via the qemu connection.
