### PR TITLE
Use vagrant-libvirt connection or generated uri

### DIFF
--- a/lib/sahara/session/libvirt.rb
+++ b/lib/sahara/session/libvirt.rb
@@ -11,37 +11,19 @@ module Sahara
         @domain=get_domain
       end
 
-      # based on VagrantPlugins::ProviderLibvirt::Action::ConnectLibvirt
+      # based on VagrantPlugins::ProviderLibvirt::Driver
       def connect_to_libvirt
+        # reuse the libvirt connection if available
+        if @machine.provider.respond_to? :connection
+          return @machine.provider.connection
+        end
+        # fallback to building a new connection
+
         # Get config options for libvirt provider.
         config = @machine.provider_config
 
-        # Setup connection uri.
-        uri = config.driver
-        if uri == "kvm"
-          uri = "qemu"
-        end
-
-        if config.connect_via_ssh
-          uri << '+ssh://'
-          if config.username
-            uri << config.username + '@'
-          end
-
-          if config.host
-            uri << config.host
-          else
-            uri << 'localhost'
-          end
-        else
-          uri << '://'
-          uri << config.host if config.host
-        end
-
-        uri << '/system?no_verify=1'
-        # set ssh key for access to libvirt host
-        home_dir = `echo ${HOME}`.chomp
-        uri << "&keyfile=#{home_dir}/.ssh/id_rsa"
+        # Use vagrant-libvirt constructed uri.
+        uri = config.uri
 
         conn_attr = {}
         conn_attr[:provider] = 'libvirt'


### PR DESCRIPTION
The vagrant-plugin now provides a driver class that can build the
connection for other plugins to leverage. Use this where possible since
it must have worked for the end user to create the virtual machines.

Alternatively fall back to using the uri built by vagrant-libvirt's
config class which will already contain the correct settings used to
previously connect to libvirt successfully.

Previously use of local socket connections and firewalls could prevent
sahara from connecting even though vagrant-libvirt worked. This ensures
that a working vagrant configuration using vagrant-libvirt will be
usable with sahara.
