### PR TITLE
Remove unused popen4 dependency

### DIFF
--- a/sahara.gemspec
+++ b/sahara.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "sahara"
 
-  s.add_dependency "popen4", "~> 0.1.2"
-
   s.add_development_dependency "bundler", ">= 1.0.0"
 
   s.files        = `git ls-files`.split("\n")


### PR DESCRIPTION
Hey @jedi4ever 

I'm looking to build an RPM to provide this plugin in Fedora which also means building its dependencies. It looks like popen4 isn't used, so removing it will make building the RPM easier. Can you release a 0.0.18 if this is merged?